### PR TITLE
Implémenter l'UI pour l'ajout de règles de transactions récurrentes

### DIFF
--- a/src/components/AddRecurringRuleModal.tsx
+++ b/src/components/AddRecurringRuleModal.tsx
@@ -1,0 +1,282 @@
+// src/components/AddRecurringRuleModal.tsx
+import React, { useEffect, useMemo } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { useAppContext } from './Layout'; // Ajuster le chemin si nécessaire
+import type { MainCategory, SubCategory, RecurringTransactionRule, Frequency, TransactionFormData } from '../types'; // Assurer que TransactionFormData est importé si on s'en inspire
+
+// Type pour les données du formulaire, excluant les champs auto-générés
+export type RecurringRuleFormData = Omit<RecurringTransactionRule, 'id' | 'lastGeneratedDate' | 'nextDueDate' | 'isActive'>;
+
+interface AddRecurringRuleModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (data: RecurringRuleFormData) => void;
+}
+
+export function AddRecurringRuleModal({ isOpen, onClose, onSave }: AddRecurringRuleModalProps) {
+  const { mainCategories, subCategories } = useAppContext();
+
+  const { register, handleSubmit, control, watch, setValue, reset, formState: { errors } } = useForm<RecurringRuleFormData>({
+    defaultValues: {
+      name: '',
+      type: 'Dépense',
+      amount: undefined,
+      mainCategoryId: '',
+      subCategoryId: '',
+      note: '',
+      frequency: 'monthly',
+      interval: 1,
+      startDate: new Date().toISOString().split('T')[0],
+      endDate: '',
+      dayOfWeek: undefined, // 0 for Sunday
+      dayOfMonth: 1,
+    }
+  });
+
+  const watchedType = watch('type');
+  const watchedMainCategoryId = watch('mainCategoryId');
+  const watchedFrequency = watch('frequency');
+
+  useEffect(() => {
+    if (isOpen) {
+      reset({ // Reset avec les valeurs par défaut à chaque ouverture
+        name: '',
+        type: 'Dépense',
+        amount: undefined,
+        mainCategoryId: mainCategories[0]?.id || '', // Pré-sélectionner si possible
+        subCategoryId: '',
+        note: '',
+        frequency: 'monthly',
+        interval: 1,
+        startDate: new Date().toISOString().split('T')[0],
+        endDate: '',
+        dayOfWeek: 0,
+        dayOfMonth: 1,
+      });
+    }
+  }, [isOpen, reset, mainCategories]);
+
+  const availableMainCategories = useMemo(() =>
+    mainCategories.filter(cat => {
+      if (watchedType === 'Dépense') return cat.budgetType !== 'Revenu';
+      return cat.budgetType === 'Revenu';
+    }),
+    [mainCategories, watchedType]
+  );
+
+  const availableSubCategories = useMemo(() =>
+    subCategories.filter(sub => sub.parentCategoryId === watchedMainCategoryId),
+    [subCategories, watchedMainCategoryId]
+  );
+
+  useEffect(() => {
+    if (!availableMainCategories.find(cat => cat.id === watchedMainCategoryId)) {
+      setValue('mainCategoryId', mainCategories[0]?.id || '');
+    }
+  }, [availableMainCategories, watchedMainCategoryId, setValue, mainCategories]);
+
+  useEffect(() => {
+    if (!availableSubCategories.find(sub => sub.id === watch('subCategoryId'))) {
+      setValue('subCategoryId', '');
+    }
+  }, [availableSubCategories, watchedMainCategoryId, setValue, watch]);
+
+  // Logique pour afficher/cacher et valider conditionnellement dayOfWeek/dayOfMonth
+  useEffect(() => {
+    if (watchedFrequency !== 'weekly') {
+      setValue('dayOfWeek', undefined);
+    }
+    if (watchedFrequency !== 'monthly' && watchedFrequency !== 'yearly') {
+      setValue('dayOfMonth', undefined);
+    }
+  }, [watchedFrequency, setValue]);
+
+
+  const onSubmit = (data: RecurringRuleFormData) => {
+    const dataToSave: RecurringRuleFormData = {
+        ...data,
+        amount: Number(data.amount),
+        interval: Number(data.interval),
+        dayOfWeek: data.frequency === 'weekly' ? Number(data.dayOfWeek) : undefined,
+        dayOfMonth: (data.frequency === 'monthly' || data.frequency === 'yearly') ? Number(data.dayOfMonth) : undefined,
+        subCategoryId: data.subCategoryId || undefined,
+        endDate: data.endDate || undefined,
+        note: data.note || undefined,
+    };
+    onSave(dataToSave);
+    onClose(); // Fermer la modale après sauvegarde
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const daysOfWeek = ["Dimanche", "Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi"];
+  const daysInMonth = Array.from({ length: 31 }, (_, i) => i + 1);
+
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50 p-4">
+      <div className="bg-white dark:bg-slate-800 rounded-lg shadow-xl w-full max-w-lg max-h-[90vh] overflow-y-auto p-6">
+        <div className="flex justify-between items-center mb-6">
+          <h2 className="text-xl font-bold">Ajouter une Règle Récurrente</h2>
+          <button onClick={onClose} className="text-2xl hover:text-red-500">×</button>
+        </div>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          {/* Nom de la règle */}
+          <div>
+            <label htmlFor="ruleName" className="block text-sm font-medium mb-1">Nom de la règle :</label>
+            <input type="text" id="ruleName"
+              {...register('name', { required: "Le nom de la règle est requis" })}
+              className={`w-full p-2 rounded bg-slate-200 dark:bg-slate-700 focus:outline-none focus:ring-2 ${errors.name ? 'ring-red-500' : 'focus:ring-sky-500'}`}
+              placeholder="Ex: Loyer, Salaire Netflix"
+            />
+            {errors.name && <p className="text-red-500 text-xs mt-1">{errors.name.message}</p>}
+          </div>
+
+          {/* Type (Dépense/Revenu) */}
+          <div>
+            <span className="text-sm font-medium">Type :</span>
+            <Controller name="type" control={control} render={({ field }) => (
+              <div className="mt-2 flex gap-4 p-1 bg-slate-200 dark:bg-slate-700 rounded-lg">
+                <button type="button" onClick={() => field.onChange('Dépense')} className={`w-full py-2 rounded-md transition-colors ${field.value === 'Dépense' ? 'bg-red-500 text-white font-semibold' : ''}`}>Dépense</button>
+                <button type="button" onClick={() => field.onChange('Revenu')} className={`w-full py-2 rounded-md transition-colors ${field.value === 'Revenu' ? 'bg-green-500 text-white font-semibold' : ''}`}>Revenu</button>
+              </div>
+            )}/>
+          </div>
+
+          {/* Montant */}
+          <div>
+            <label htmlFor="ruleAmount" className="block text-sm font-medium mb-1">Montant :</label>
+            <div className="relative">
+              <input type="number" id="ruleAmount"
+                {...register('amount', { required: "Le montant est requis", valueAsNumber: true, min: { value: 0.01, message: "Le montant doit être positif" } })}
+                className={`w-full p-2 pr-8 rounded bg-slate-200 dark:bg-slate-700 focus:outline-none focus:ring-2 ${errors.amount ? 'ring-red-500' : 'focus:ring-sky-500'}`}
+                placeholder="0.00" step="0.01"
+              />
+              <span className="absolute inset-y-0 right-3 flex items-center text-gray-500">€</span>
+            </div>
+            {errors.amount && <p className="text-red-500 text-xs mt-1">{errors.amount.message}</p>}
+          </div>
+
+          {/* Catégories */}
+          <div>
+            <label htmlFor="ruleMainCategoryId" className="block text-sm font-medium mb-1">Catégorie :</label>
+            <select id="ruleMainCategoryId"
+              {...register('mainCategoryId', { required: "La catégorie est requise" })}
+              className={`w-full p-2 rounded bg-slate-200 dark:bg-slate-700 focus:outline-none focus:ring-2 ${errors.mainCategoryId ? 'ring-red-500' : 'focus:ring-sky-500'}`}
+            >
+              <option value="" disabled>Sélectionner une catégorie</option>
+              {availableMainCategories.map(cat => (<option key={cat.id} value={cat.id}>{cat.name}</option>))}
+            </select>
+            {errors.mainCategoryId && <p className="text-red-500 text-xs mt-1">{errors.mainCategoryId.message}</p>}
+          </div>
+          {availableSubCategories.length > 0 && (
+            <div>
+              <label htmlFor="ruleSubCategoryId" className="block text-sm font-medium mb-1">Sous-Catégorie :</label>
+              <select id="ruleSubCategoryId" {...register('subCategoryId')}
+                className="w-full p-2 rounded bg-slate-200 dark:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-sky-500"
+              >
+                <option value="">(Optionnel)</option>
+                {availableSubCategories.map(sub => (<option key={sub.id} value={sub.id}>{sub.name}</option>))}
+              </select>
+            </div>
+          )}
+
+          {/* Fréquence et Intervalle */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="ruleFrequency" className="block text-sm font-medium mb-1">Fréquence :</label>
+              <select id="ruleFrequency" {...register('frequency', { required: "Fréquence requise"})}
+                className={`w-full p-2 rounded bg-slate-200 dark:bg-slate-700 focus:outline-none focus:ring-2 ${errors.frequency ? 'ring-red-500' : 'focus:ring-sky-500'}`}
+              >
+                <option value="daily">Quotidien</option>
+                <option value="weekly">Hebdomadaire</option>
+                <option value="monthly">Mensuel</option>
+                <option value="yearly">Annuel</option>
+              </select>
+              {errors.frequency && <p className="text-red-500 text-xs mt-1">{errors.frequency.message}</p>}
+            </div>
+            <div>
+              <label htmlFor="ruleInterval" className="block text-sm font-medium mb-1">Intervalle :</label>
+              <input type="number" id="ruleInterval"
+                {...register('interval', { required: "Intervalle requis", valueAsNumber: true, min: { value: 1, message: "Minimum 1" }})}
+                className={`w-full p-2 rounded bg-slate-200 dark:bg-slate-700 focus:outline-none focus:ring-2 ${errors.interval ? 'ring-red-500' : 'focus:ring-sky-500'}`}
+                placeholder="1"
+              />
+              {errors.interval && <p className="text-red-500 text-xs mt-1">{errors.interval.message}</p>}
+            </div>
+          </div>
+
+          {/* Champs spécifiques à la fréquence */}
+          {watchedFrequency === 'weekly' && (
+            <div>
+              <label htmlFor="ruleDayOfWeek" className="block text-sm font-medium mb-1">Jour de la semaine :</label>
+              <select id="ruleDayOfWeek"
+                {...register('dayOfWeek', { required: "Jour requis", valueAsNumber: true })}
+                className={`w-full p-2 rounded bg-slate-200 dark:bg-slate-700 focus:outline-none focus:ring-2 ${errors.dayOfWeek ? 'ring-red-500' : 'focus:ring-sky-500'}`}
+              >
+                {daysOfWeek.map((day, index) => <option key={index} value={index}>{day}</option>)}
+              </select>
+              {errors.dayOfWeek && <p className="text-red-500 text-xs mt-1">{errors.dayOfWeek.message}</p>}
+            </div>
+          )}
+          {(watchedFrequency === 'monthly' || watchedFrequency === 'yearly') && (
+            <div>
+              <label htmlFor="ruleDayOfMonth" className="block text-sm font-medium mb-1">Jour du mois :</label>
+              <select id="ruleDayOfMonth"
+                {...register('dayOfMonth', { required: "Jour requis", valueAsNumber: true, min: 1, max: 31 })}
+                className={`w-full p-2 rounded bg-slate-200 dark:bg-slate-700 focus:outline-none focus:ring-2 ${errors.dayOfMonth ? 'ring-red-500' : 'focus:ring-sky-500'}`}
+              >
+                {daysInMonth.map(day => <option key={day} value={day}>{day}</option>)}
+              </select>
+              {errors.dayOfMonth && <p className="text-red-500 text-xs mt-1">{errors.dayOfMonth.message}</p>}
+            </div>
+          )}
+
+          {/* Dates de début et de fin */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="ruleStartDate" className="block text-sm font-medium mb-1">Date de début :</label>
+              <input type="date" id="ruleStartDate"
+                {...register('startDate', { required: "Date de début requise"})}
+                className={`w-full p-2 rounded bg-slate-200 dark:bg-slate-700 focus:outline-none focus:ring-2 ${errors.startDate ? 'ring-red-500' : 'focus:ring-sky-500'}`}
+              />
+              {errors.startDate && <p className="text-red-500 text-xs mt-1">{errors.startDate.message}</p>}
+            </div>
+            <div>
+              <label htmlFor="ruleEndDate" className="block text-sm font-medium mb-1">Date de fin (optionnel) :</label>
+              <input type="date" id="ruleEndDate"
+                {...register('endDate', {
+                    validate: (value, formValues) => {
+                        if (value && formValues.startDate && value < formValues.startDate) {
+                            return "La date de fin ne peut pas être antérieure à la date de début";
+                        }
+                        return true;
+                    }
+                })}
+                className={`w-full p-2 rounded bg-slate-200 dark:bg-slate-700 focus:outline-none focus:ring-2 ${errors.endDate ? 'ring-red-500' : 'focus:ring-sky-500'}`}
+              />
+              {errors.endDate && <p className="text-red-500 text-xs mt-1">{errors.endDate.message}</p>}
+            </div>
+          </div>
+
+          {/* Note */}
+          <div>
+            <label htmlFor="ruleNote" className="block text-sm font-medium mb-1">Note (Optionnel) :</label>
+            <textarea id="ruleNote" {...register('note')}
+              className="w-full p-2 rounded bg-slate-200 dark:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-sky-500"
+              rows={2} placeholder="Détails supplémentaires..."
+            ></textarea>
+          </div>
+
+          <div className="flex justify-end gap-4 pt-6">
+            <button type="button" onClick={onClose} className="px-4 py-2 rounded bg-gray-200 dark:bg-slate-600 hover:bg-gray-300 dark:hover:bg-slate-500">Annuler</button>
+            <button type="submit" className="px-4 py-2 rounded bg-sky-500 text-white font-semibold hover:bg-sky-600">Enregistrer la Règle</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/RecurringTransactionsPage.tsx
+++ b/src/pages/RecurringTransactionsPage.tsx
@@ -1,15 +1,22 @@
 // src/pages/RecurringTransactionsPage.tsx
-import React from 'react';
+import React, { useState } from 'react'; // useState ajouté
 import { useAppContext } from '../components/Layout';
-import { Link } from 'react-router-dom'; // Pour le bouton "Ajouter"
+// import { Link } from 'react-router-dom'; // Plus besoin pour le bouton "Ajouter" si on utilise une modale
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
+import { AddRecurringRuleModal, type RecurringRuleFormData } from '../components/AddRecurringRuleModal'; // Importer la modale
 
 export function RecurringTransactionsPage() {
-  const { recurringTransactionRules, onDeleteRecurringRule, onUpdateRecurringRule } = useAppContext();
+  const { recurringTransactionRules, onDeleteRecurringRule, onUpdateRecurringRule, onAddRecurringRule } = useAppContext();
+  const [isAddModalOpen, setIsAddModalOpen] = useState(false);
+
+  const handleSaveNewRule = (data: RecurringRuleFormData) => {
+    onAddRecurringRule(data);
+    // La modale se ferme déjà d'elle-même après onSave, donc pas besoin de setIsAddModalOpen(false) ici
+    // si onClose est bien appelé dans la modale après onSave.
+  };
 
   const handleToggleActive = (ruleId: string, currentIsActive: boolean) => {
-    // Appeler onUpdateRecurringRule pour inverser la valeur de isActive
     // Le nom et autres détails ne changent pas, donc on peut les extraire de la règle existante si besoin pour le toast
     const ruleToUpdate = recurringTransactionRules.find(r => r.id === ruleId);
     if (ruleToUpdate) {
@@ -49,12 +56,18 @@ export function RecurringTransactionsPage() {
       <header className="flex justify-between items-center">
         <h1 className="text-3xl font-bold">Transactions Récurrentes</h1>
         <button
-            onClick={() => console.log("TODO: Open AddRecurringRuleModal")}
+            onClick={() => setIsAddModalOpen(true)}
             className="bg-sky-500 text-white font-bold py-2 px-4 rounded-lg hover:bg-sky-600 transition-colors"
         >
           (+) Ajouter une Règle
         </button>
       </header>
+
+      <AddRecurringRuleModal
+        isOpen={isAddModalOpen}
+        onClose={() => setIsAddModalOpen(false)}
+        onSave={handleSaveNewRule}
+      />
 
       {recurringTransactionRules.length === 0 ? (
         <div className="text-center py-10 bg-white dark:bg-slate-800 rounded-lg shadow-md">


### PR DESCRIPTION
Ce commit introduit l'interface utilisateur pour ajouter des règles de transactions récurrentes.

Changements principaux :

1.  **`src/pages/RecurringTransactionsPage.tsx` :**
    *   Affiche la liste des règles existantes avec des informations clés (nom, montant, fréquence, prochaine échéance, statut).
    *   Permet d'activer/désactiver et de supprimer des règles.
    *   Intègre un bouton "(+) Ajouter une Règle" qui ouvre une modale.

2.  **`src/components/AddRecurringRuleModal.tsx` (Nouveau) :**
    *   Nouvelle modale utilisant `react-hook-form` pour la saisie des détails d'une règle récurrente (nom, type, montant, catégorie, fréquence, intervalle, dates, jours spécifiques à la fréquence).
    *   Inclut la validation des champs et l'affichage conditionnel des options basées sur la fréquence.
    *   Réinitialise les champs à chaque ouverture.
    *   Appelle la fonction `onAddRecurringRule` (du contexte) lors de la soumission.

3.  **Routage et Navigation :**
    *   Ajout d'une route `/recurring` pour `RecurringTransactionsPage.tsx` dans `main.tsx`.
    *   Ajout d'un lien "Récurrentes" dans la barre de navigation (`Layout.tsx`).

L'interface de base pour visualiser et ajouter des règles de transactions récurrentes est maintenant fonctionnelle. Les prochaines étapes incluront la modale d'édition et la logique de génération des transactions.