### PR TITLE
Implémenter la génération de transactions récurrentes

### DIFF
--- a/src/utils/transactionGenerator.test.ts
+++ b/src/utils/transactionGenerator.test.ts
@@ -1,0 +1,200 @@
+// src/utils/transactionGenerator.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { generateTransactionsForRule } from './transactionGenerator';
+import type { RecurringTransactionRule, TransactionFormData } from '../types';
+import { formatISO, parseISO, addDays, subDays, isSameDay, isBefore, addMonths } from 'date-fns'; // Added isSameDay, isBefore, addMonths
+
+describe('generateTransactionsForRule', () => {
+  const baseRule: Omit<RecurringTransactionRule, 'id' | 'nextDueDate' | 'frequency' | 'interval' | 'startDate' | 'name' | 'isActive' | 'lastGeneratedDate'> = {
+    type: 'Dépense',
+    amount: 100,
+    mainCategoryId: 'cat1',
+    note: 'Test Rule',
+  };
+
+  const today = new Date(); // Date limite pour la génération
+  const todayStr = formatISO(today, { representation: 'date' });
+
+  it('should generate no transactions if nextDueDate is in the future', () => {
+    const futureDate = formatISO(addDays(today, 5), { representation: 'date' });
+    const rule: RecurringTransactionRule = {
+      ...baseRule,
+      id: 'rule1',
+      name: 'Future Rule',
+      frequency: 'daily',
+      interval: 1,
+      startDate: todayStr,
+      nextDueDate: futureDate, // Échéance dans le futur
+      isActive: true,
+    };
+    const result = generateTransactionsForRule(rule, today);
+    expect(result.transactionsToCreate.length).toBe(0);
+    expect(result.newLastGeneratedDate).toBeUndefined();
+    expect(result.newNextDueDate).toBe(futureDate); // Doit rester la même
+  });
+
+  it('should generate one transaction if nextDueDate is today', () => {
+    const rule: RecurringTransactionRule = {
+      ...baseRule,
+      id: 'rule2',
+      name: 'Today Rule',
+      frequency: 'daily',
+      interval: 1,
+      startDate: todayStr,
+      nextDueDate: todayStr,
+      isActive: true,
+    };
+    const result = generateTransactionsForRule(rule, today);
+    expect(result.transactionsToCreate.length).toBe(1);
+    expect(result.transactionsToCreate[0].date).toBe(todayStr);
+    expect(result.transactionsToCreate[0].note).toBe('Today Rule - Test Rule (Récurrent)');
+    expect(result.newLastGeneratedDate).toBe(todayStr);
+    expect(result.newNextDueDate).toBe(formatISO(addDays(today, 1), { representation: 'date' }));
+  });
+
+  it('should generate multiple transactions for a daily rule over several days', () => {
+    const startDate = subDays(today, 3);
+    const startDateStr = formatISO(startDate, { representation: 'date' });
+    const rule: RecurringTransactionRule = {
+      ...baseRule,
+      id: 'rule3',
+      name: 'Daily Multi',
+      frequency: 'daily',
+      interval: 1,
+      startDate: startDateStr,
+      nextDueDate: startDateStr, // Commence à la date de début
+      isActive: true,
+    };
+    // limitDate est 'today', donc on attend 4 transactions: startDate, startDate+1, startDate+2, startDate+3 (today)
+    const result = generateTransactionsForRule(rule, today);
+    expect(result.transactionsToCreate.length).toBe(4);
+    expect(result.transactionsToCreate[0].date).toBe(startDateStr);
+    expect(result.transactionsToCreate[3].date).toBe(todayStr);
+    expect(result.newLastGeneratedDate).toBe(todayStr);
+    expect(result.newNextDueDate).toBe(formatISO(addDays(today, 1), { representation: 'date' }));
+  });
+
+  it('should respect endDate', () => {
+    const startDate = subDays(today, 5);
+    const endDate = subDays(today, 2); // Se termine il y a 2 jours
+    const rule: RecurringTransactionRule = {
+      ...baseRule,
+      id: 'rule4',
+      name: 'Ended Rule',
+      frequency: 'daily',
+      interval: 1,
+      startDate: formatISO(startDate, { representation: 'date' }),
+      nextDueDate: formatISO(startDate, { representation: 'date' }),
+      endDate: formatISO(endDate, { representation: 'date' }),
+      isActive: true,
+    };
+    // Devrait générer pour startDate, startDate+1, startDate+2, startDate+3 (qui est endDate)
+    // startDate = today-5, endDate = today-2. Transactions pour: T-5, T-4, T-3, T-2. (4 transactions)
+    const result = generateTransactionsForRule(rule, today);
+    expect(result.transactionsToCreate.length).toBe(4);
+    expect(result.newLastGeneratedDate).toBe(formatISO(endDate, { representation: 'date' }));
+    // La prochaine date calculée sera après endDate, donc c'est la bonne nextDueDate à stocker
+    expect(result.newNextDueDate).toBe(formatISO(addDays(endDate, 1), { representation: 'date' }));
+  });
+
+  it('should not generate transactions if rule is inactive', () => {
+    const rule: RecurringTransactionRule = {
+      ...baseRule,
+      id: 'rule5',
+      name: 'Inactive Rule',
+      frequency: 'daily',
+      interval: 1,
+      startDate: todayStr,
+      nextDueDate: todayStr,
+      isActive: false, // Inactive
+    };
+    const result = generateTransactionsForRule(rule, today);
+    expect(result.transactionsToCreate.length).toBe(0);
+    expect(result.newLastGeneratedDate).toBeUndefined();
+    expect(result.newNextDueDate).toBe(todayStr); // nextDueDate ne change pas
+  });
+
+  it('should use lastGeneratedDate if provided and nextDueDate is older or same', () => {
+    // Ce test est plus pour la logique d'appel dans App.tsx,
+    // generateTransactionsForRule commence toujours par rule.nextDueDate.
+    // La logique de mise à jour de nextDueDate avant d'appeler generateTransactionsForRule est cruciale.
+    // Ici, on s'assure juste que si nextDueDate est dans le passé, ça génère.
+    const lastGen = subDays(today, 5);
+    const nextDue = subDays(today, 3); // nextDueDate est après lastGeneratedDate
+
+    const rule: RecurringTransactionRule = {
+      ...baseRule,
+      id: 'rule6',
+      name: 'With LastGen',
+      frequency: 'daily',
+      interval: 1,
+      startDate: formatISO(subDays(today,10), {representation: 'date'}),
+      lastGeneratedDate: formatISO(lastGen, {representation: 'date'}),
+      nextDueDate: formatISO(nextDue, {representation: 'date'}), // Commence à partir d'ici
+      isActive: true,
+    };
+    // limitDate est 'today'. Devrait générer pour T-3, T-2, T-1, T. (4 transactions)
+    const result = generateTransactionsForRule(rule, today);
+    expect(result.transactionsToCreate.length).toBe(4);
+    expect(result.transactionsToCreate[0].date).toBe(formatISO(nextDue, { representation: 'date' }));
+    expect(result.newLastGeneratedDate).toBe(todayStr);
+    expect(result.newNextDueDate).toBe(formatISO(addDays(today, 1), { representation: 'date' }));
+  });
+
+  it('monthly rule: should generate for current month if due and not past limitDate', () => {
+    const firstOfMonth = formatISO(new Date(today.getFullYear(), today.getMonth(), 1), {representation: 'date'});
+    const rule: RecurringTransactionRule = {
+      ...baseRule,
+      id: 'rule7',
+      name: 'Monthly Test',
+      frequency: 'monthly',
+      interval: 1,
+      startDate: firstOfMonth,
+      nextDueDate: firstOfMonth, // Due le 1er du mois actuel
+      dayOfMonth: 1,
+      isActive: true,
+    };
+    const result = generateTransactionsForRule(rule, today); // today
+    // Si today est le 1er, length = 1, nextDueDate = 1er mois prochain
+    // Si today est après le 1er, length = 1, nextDueDate = 1er mois prochain
+    if (isSameDay(parseISO(firstOfMonth), today) || isBefore(parseISO(firstOfMonth), today)) {
+        expect(result.transactionsToCreate.length).toBe(1);
+        expect(result.transactionsToCreate[0].date).toBe(firstOfMonth);
+        expect(result.newLastGeneratedDate).toBe(firstOfMonth);
+        const expectedNextDue = formatISO(addMonths(parseISO(firstOfMonth), 1), {representation: 'date'});
+        expect(result.newNextDueDate).toBe(expectedNextDue);
+    } else { // firstOfMonth est dans le futur (ne devrait pas arriver avec ce setup de test)
+        expect(result.transactionsToCreate.length).toBe(0);
+        expect(result.newNextDueDate).toBe(firstOfMonth);
+    }
+  });
+
+  it('weekly rule: should generate for current week if due', () => {
+    // Example: rule for every Monday, today is Wednesday.
+    // Last Monday was 2 days ago. nextDueDate should be that Monday.
+    const todayIs = today.getDay(); // 0=Sun, 6=Sat
+    const targetDayOfWeek = (todayIs + 5) % 7; // Un lundi, si today est Mercredi (2+5)%7 = 0 (Dimanche), (0+5)%7 = 5 (Vendredi)
+                                            // Prenons un lundi (1) comme targetDayOfWeek pour simplifier.
+    const mondayThisWeekOrPast = formatISO(subDays(today, (todayIs + 6) % 7), {representation: 'date'});
+
+
+    const rule: RecurringTransactionRule = {
+      ...baseRule,
+      id: 'rule8',
+      name: 'Weekly Test',
+      frequency: 'weekly',
+      interval: 1,
+      startDate: mondayThisWeekOrPast,
+      nextDueDate: mondayThisWeekOrPast,
+      dayOfWeek: 1, // Lundi
+      isActive: true,
+    };
+    const result = generateTransactionsForRule(rule, today);
+    expect(result.transactionsToCreate.length).toBe(1);
+    expect(result.transactionsToCreate[0].date).toBe(mondayThisWeekOrPast);
+    expect(result.newLastGeneratedDate).toBe(mondayThisWeekOrPast);
+    expect(result.newNextDueDate).toBe(formatISO(addDays(parseISO(mondayThisWeekOrPast), 7), { representation: 'date' }));
+  });
+
+
+});

--- a/src/utils/transactionGenerator.ts
+++ b/src/utils/transactionGenerator.ts
@@ -1,0 +1,66 @@
+// src/utils/transactionGenerator.ts
+import { parseISO, isBefore, isSameDay, startOfDay } from 'date-fns';
+import type { RecurringTransactionRule, TransactionFormData, Frequency } from '../types';
+import { calculateNextDueDate } from './dateLogic'; // calculateNextDueDate est suffisant ici
+
+interface GenerationResult {
+  transactionsToCreate: TransactionFormData[];
+  newLastGeneratedDate?: string; // La date de la dernière transaction réellement générée
+  newNextDueDate: string; // La prochaine date d'échéance pour la règle
+}
+
+/**
+ * Génère les transactions dues pour une règle récurrente jusqu'à une date limite.
+ * @param rule La règle de transaction récurrente.
+ * @param limitDate La date jusqu'à laquelle générer les transactions (inclusivement).
+ * @returns Un objet contenant les transactions à créer et les dates mises à jour pour la règle.
+ */
+export function generateTransactionsForRule(
+  rule: RecurringTransactionRule,
+  limitDate: Date // Objet Date JavaScript
+): GenerationResult {
+  const transactionsToCreate: TransactionFormData[] = [];
+  let currentProcessingDate = parseISO(rule.nextDueDate); // Commence par la prochaine échéance connue
+  const ruleEndDate = rule.endDate ? startOfDay(parseISO(rule.endDate)) : null;
+  const normalizedLimitDate = startOfDay(limitDate); // Normaliser la date limite
+
+  let latestGeneratedDateInThisRun: string | undefined = undefined;
+  let nextCalculatedDueDate = rule.nextDueDate; // Initialiser avec la nextDueDate actuelle de la règle
+
+  // Boucler tant que la date de traitement actuelle est avant ou égale à la date limite
+  // et (si une date de fin de règle existe) avant ou égale à la date de fin de la règle.
+  while (
+    (isBefore(currentProcessingDate, normalizedLimitDate) || isSameDay(currentProcessingDate, normalizedLimitDate)) &&
+    (!ruleEndDate || (isBefore(currentProcessingDate, ruleEndDate) || isSameDay(currentProcessingDate, ruleEndDate))) &&
+    rule.isActive // Ne générer que si la règle est active
+  ) {
+    // Créer la transaction
+    const newTransaction: TransactionFormData = {
+      type: rule.type,
+      amount: rule.amount,
+      date: nextCalculatedDueDate, // Utiliser la date d'échéance calculée pour la transaction
+      mainCategoryId: rule.mainCategoryId,
+      subCategoryId: rule.subCategoryId,
+      note: `${rule.name}${rule.note ? ` - ${rule.note}` : ''} (Récurrent)`,
+    };
+    transactionsToCreate.push(newTransaction);
+    latestGeneratedDateInThisRun = nextCalculatedDueDate;
+
+    // Calculer la prochaine date de traitement pour la *prochaine itération potentielle*
+    currentProcessingDate = parseISO(calculateNextDueDate(
+      nextCalculatedDueDate, // La base est la date qu'on vient de générer
+      rule.frequency,
+      rule.interval,
+      rule.dayOfWeek,
+      rule.dayOfMonth
+    ));
+    // Mettre à jour nextCalculatedDueDate pour la valeur de retour et la prochaine boucle
+    nextCalculatedDueDate = currentProcessingDate.toISOString().split('T')[0];
+  }
+
+  return {
+    transactionsToCreate,
+    newLastGeneratedDate: latestGeneratedDateInThisRun, // Sera undefined si aucune transaction n'a été générée
+    newNextDueDate: nextCalculatedDueDate, // La prochaine date d'échéance, même si aucune transaction n'a été générée dans cet appel
+  };
+}


### PR DESCRIPTION
Ce commit finalise la fonctionnalité de base des transactions récurrentes en ajoutant la logique de génération automatique des transactions.

Changements principaux :

1.  **`src/utils/transactionGenerator.ts` (Nouveau) :**
    *   Introduction de la fonction `generateTransactionsForRule`.
    *   Cette fonction prend une règle récurrente et une date limite.
    *   Elle calcule et retourne les `TransactionFormData` dues jusqu'à la date limite, en respectant la fréquence, l'intervalle, la date de fin de la règle, et son statut d'activité.
    *   Elle retourne également les nouvelles `lastGeneratedDate` et `nextDueDate` pour la règle.
    *   Utilise `calculateNextDueDate` de `dateLogic.ts` pour déterminer les échéances successives.

2.  **`src/utils/transactionGenerator.test.ts` (Nouveau) :**
    *   Tests unitaires pour `generateTransactionsForRule` couvrant divers scénarios (aucune génération, génération unique/multiple, respect de `endDate`, règle inactive, etc.).

3.  **`App.tsx` Mis à Jour :**
    *   Import et utilisation de `generateTransactionsForRule`.
    *   Nouvelle fonction `processRecurringTransactions` :
        *   Itère sur les règles récurrentes actives.
        *   Appelle `generateTransactionsForRule` pour chacune.
        *   Ajoute les transactions générées à l'état global `transactions` (avec des ID uniques).
        *   Met à jour les règles récurrentes avec les nouvelles `lastGeneratedDate` et `nextDueDate`.
        *   Affiche une notification `toast.info` pour informer du nombre de transactions générées.
    *   `processRecurringTransactions` est appelée une fois au montage du composant `App` via un `useEffect`.

Avec ces changements, l'application génère automatiquement les transactions récurrentes dues au chargement, en se basant sur les règles définies par l'utilisateur.